### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/otheramounts.php
+++ b/otheramounts.php
@@ -84,7 +84,7 @@ function otheramounts_getsetting() {
       'return' => "otheramount_pricefields",
     ));
   }
-  catch (CiviCRM_API3_Exception $e) {
+  catch (CRM_Core_Exception $e) {
     $error = $e->getMessage();
     CRM_Core_Error::debug_log_message(ts('API Error %1', array(
       'domain' => 'com.aghstrategies.otheramounts',
@@ -123,7 +123,7 @@ function otheramounts_civicrm_postProcess($formName, &$form) {
         'otheramount_pricefields' => $fieldsToAddOtherAmountOptionFor,
       ));
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(ts('API Error %1', array(
         'domain' => 'com.aghstrategies.otheramounts',


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.